### PR TITLE
Fix: tutorial1 - Bob's cred_ex_id is a string, should be variable

### DIFF
--- a/tutorials/1. Learning Aries, ACA-Py and the Basic Controller/notebooks/bob/2 Credentials/Part 2 - Issue Credential.ipynb
+++ b/tutorials/1. Learning Aries, ACA-Py and the Basic Controller/notebooks/bob/2 Credentials/Part 2 - Issue Credential.ipynb
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "record = await agent_controller.issuer.send_request_for_record(\"cred_ex_id\")\n",
+    "record = await agent_controller.issuer.send_request_for_record(cred_ex_id)\n",
     "state = record['state']\n",
     "role = record['role']\n",
     "print(f\"Credential exchange {cred_ex_id}, role: {role}, state: {state}\")"


### PR DESCRIPTION
## Description
Fixes typo: Tutorial 1, Part 2: cred_ex_id is mistakenly wrapped in quotes, it should be a variable

## Affected Dependencies
N/A

## How has this been tested?
- Manually, going through tutorial

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
